### PR TITLE
Adding Mumbai deployment CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,26 @@
+name: Deploy Graph
+on:
+  push:
+    branches: main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Install
+        run: yarn --frozen-lockfile
+      - name: Codegen
+        run: yarn codegen
+      - name: Build
+        run: yarn build
+      - uses: gtaschuk/graph-deploy@v0.1.0
+        with:
+          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+          graph_subgraph_name: "open-format"
+          graph_account: "simpleweb"
+          graph_config_file: "subgraph.mumbai.yml"


### PR DESCRIPTION
In this PR deployment CI action has been setup using the package - https://github.com/marketplace/actions/graph-deploy.

When code is push to main the subgraph will be deployed to the mumbai hosted service instance. -https://thegraph.com/hosted-service/subgraph/simpleweb/open-format

After we get this CI working we could set up a production branch which deploys to the main net instance.